### PR TITLE
Added null check for tag in clearAppNotificationsByTag on Android

### DIFF
--- a/android/src/main/java/com/wescj/eraser/EraserPlugin.java
+++ b/android/src/main/java/com/wescj/eraser/EraserPlugin.java
@@ -39,7 +39,7 @@ public class EraserPlugin implements FlutterPlugin, MethodCallHandler {
       NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
       StatusBarNotification[] notifications = notificationManager.getActiveNotifications();
       for (StatusBarNotification notification : notifications) {
-        if(notification.getTag().equals(tag)){
+        if(notification.getTag() != null && notification.getTag().equals(tag)){
           notificationManager.cancel(tag, notification.getId());
         }
       }


### PR DESCRIPTION
This fixes a NullPointerException when trying to clear notifications by tag when there are also notifications that do not have the tag attribute set.
Thank you for your work on this package.