### PR TITLE
Add the option to clear multiple notifications wit the same tag pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,39 @@
+## 3.0.1
+
+Add the option to clear multiple notifications that their tag contains given pattern
+
 ## 3.0.0
-* Update compileSdk for Android to 34
-* Use Gradle's declarative plugins block
-* Upgrade dependencies
+
+- Update compileSdk for Android to 34
+- Use Gradle's declarative plugins block
+- Upgrade dependencies
 
 ## 2.0.2
 
-* Fix a NullPointerException when trying to clear notifications by tag when there are also notifications that do not have the tag attribute set. Credit to
+- Fix a NullPointerException when trying to clear notifications by tag when there are also notifications that do not have the tag attribute set. Credit to
   mschudt for submitting the PR.
 
 ## 2.0.1
 
-* Remove hardcoded notification id so that all notifications with a certain tag are removed, regardless of their id
+- Remove hardcoded notification id so that all notifications with a certain tag are removed, regardless of their id
 
 ## 2.0.0
 
-* Migrate to null-safety
+- Migrate to null-safety
 
 ## 1.0.2
 
-* Add more information and examples to the README.md file
+- Add more information and examples to the README.md file
 
 ## 1.0.1
 
-* Use the dartfmt command to format all Dart source code
-* Add some documentation to Dart source code
-* Change src attribute of GIF in readme in an attempt to show GIF correctly on Pub website
+- Use the dartfmt command to format all Dart source code
+- Add some documentation to Dart source code
+- Change src attribute of GIF in readme in an attempt to show GIF correctly on Pub website
 
 ## 1.0.0
 
 Initial version of the plugin.
-* Clear all notifications received by your Flutter app, or selected notifications based on a tag
-* Clear the iOS badge count, with the option to remove or retain notifications in the notification center
+
+- Clear all notifications received by your Flutter app, or selected notifications based on a tag
+- Clear the iOS badge count, with the option to remove or retain notifications in the notification center

--- a/README.md
+++ b/README.md
@@ -67,30 +67,63 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 In order to dismiss notifications selectively, the notification needs to include a tag (for Android) and an apns-collapse-id header (for iOS). The below code snippet shows how to do this using a Google Cloud Function written in node.js:
 
 ```javascript
-const notificationTag: string = 'notificationTag';
+const notificationTag: string = "notificationTag";
 
 await admin.messaging().sendMulticast({
-        tokens: deviceTokens,
-        notification: {
-            title: 'Notification Title',
-            body: 'Notification message',
-        },
-        android: {
-            notification: {
-                tag: notificationTag,
-            },
-        },
-        apns: {
-            headers: {
-                'apns-collapse-id': notificationTag,
-            },
-        },
-    });
+  tokens: deviceTokens,
+  notification: {
+    title: "Notification Title",
+    body: "Notification message",
+  },
+  android: {
+    notification: {
+      tag: notificationTag,
+    },
+  },
+  apns: {
+    headers: {
+      "apns-collapse-id": notificationTag,
+    },
+  },
+});
 ```
 
 The `clearAppNotificationsByTag` method can then be used to clear all notifications with that notificationTag.
 
+## Clear by pattern
+
+In case you want to clear "group" of notifications you can use `clearAppNotificationsByTagThatContains`
+
+```
+Eraser.clearAppNotificationsByTagThatContains(idGroup);
+```
+
+That option allows you to create grouped notifications by sending notification with `tag` / `apns-collapse-id` that contains specific pattern and than clean all of them at once
+
+```javascript
+const notificationTag: string = someGroupId + "_" + messageUUid;
+
+await admin.messaging().sendMulticast({
+  tokens: deviceTokens,
+  notification: {
+    title: "Notification Title",
+    body: "Notification message",
+  },
+  android: {
+    notification: {
+      tag: notificationTag,
+    },
+  },
+  apns: {
+    headers: {
+      "apns-collapse-id": notificationTag,
+    },
+  },
+});
+```
+
 ## Badge count
+
 Upon receiving push notifications, iOS devices typically display a red dot on top of the app icon with a number inside. If iOS notifications are dismissed, this badge count remains, so it was necessary to provide some functionality to remove this badge count.<br />
 By default, dismissing the badge count also dismisses all notifications from the iOS notification center. If this is acceptable, use the `resetBadgeCountAndRemoveNotificationsFromCenter` method.<br />
 If however you require the notifications to remain in the notification center after dismissing the badge count, then the `resetBadgeCountButKeepNotificationsInCenter` method should be used.<br />
@@ -98,6 +131,7 @@ If however you require the notifications to remain in the notification center af
 Android 8.0 introduced similar 'badge count' functionality. However Android calls this functionality 'notification badges', and the number inside the badge is known as a 'notification count'. When notifications are dismissed, Android automatically gets rid of the notification count. For this reason, the `resetBadgeCount...` methods do nothing when called on an Android device.
 
 ## iOS compatibility
+
 This plugin is only capable of clearing notifications on iOS devices running iOS 10 or above. The methods will return silently without dismissing notifications if running on devices with iOS 9 or lower. This was deemed acceptable because it seems that the Firebase plugins themselves only support iOS 10 and above.
 
 ## Example app recording
@@ -111,5 +145,6 @@ Ideally, this functionality would be integrated with the FlutterFire Cloud Messa
 That is why I decided to put the 'eraser' functionality in a separate plugin, so that users of the plugin can call it from their main method (to clear notifications when the app is first started) or from a WidgetsBindingObserver (to clear notifications when the app comes back into the foreground), as explained in the Getting Started section above.
 
 ## Tests
+
 This plugin is quite simple and just delegates to platform-specific code in order to provide its functionality. This platform-specific code should already be tested by Google and Apple. For that reason, there isn't really anything to test and the plugin has no unit tests.<br />
 If anyone can think of any possible unit tests, then feel free to suggest them, or open a pull request.

--- a/android/src/main/java/com/wescj/eraser/EraserPlugin.java
+++ b/android/src/main/java/com/wescj/eraser/EraserPlugin.java
@@ -14,10 +14,6 @@ import io.flutter.plugin.common.MethodChannel.Result;
 
 /** EraserPlugin */
 public class EraserPlugin implements FlutterPlugin, MethodCallHandler {
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
   private MethodChannel channel;
   private Context context;
 
@@ -30,22 +26,37 @@ public class EraserPlugin implements FlutterPlugin, MethodCallHandler {
 
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-    if("clearAllAppNotifications".equals(call.method)) {
+    if ("clearAllAppNotifications".equals(call.method)) {
       NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
       notificationManager.cancelAll();
       result.success(null);
-    } else if("clearAppNotificationsByTag".equals(call.method)) {
+    } else if ("clearAppNotificationsByTag".equals(call.method)) {
       String tag = call.argument("tag");
       NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
       StatusBarNotification[] notifications = notificationManager.getActiveNotifications();
       for (StatusBarNotification notification : notifications) {
-        if(notification.getTag() != null && notification.getTag().equals(tag)){
+        if (notification.getTag() != null && notification.getTag().equals(tag)) {
           notificationManager.cancel(tag, notification.getId());
         }
       }
       result.success(null);
+    } else if ("clearAppNotificationsByTagThatContains".equals(call.method)) {
+      String pattern = call.argument("pattern");
+      clearNotificationsByTagPattern(pattern);
+      result.success(null);
     } else {
       result.notImplemented();
+    }
+  }
+
+  private void clearNotificationsByTagPattern(String pattern) {
+    NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    StatusBarNotification[] notifications = notificationManager.getActiveNotifications();
+    for (StatusBarNotification notification : notifications) {
+      String tag = notification.getTag();
+      if (tag != null && tag.contains(pattern)) {
+        notificationManager.cancel(tag, notification.getId());
+      }
     }
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -79,7 +79,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.2"
+    version: "3.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -187,18 +187,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -219,18 +219,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   move_to_background:
     dependency: "direct main"
     description:
@@ -304,10 +304,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -328,10 +328,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftEraserPlugin.swift
+++ b/ios/Classes/SwiftEraserPlugin.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import UserNotifications
 
 public class SwiftEraserPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -9,29 +10,48 @@ public class SwiftEraserPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    if(call.method  == "clearAllAppNotifications") {
-        if #available(iOS 10.0, *) {
-            UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+    if call.method == "clearAllAppNotifications" {
+      if #available(iOS 10.0, *) {
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+      }
+      result(nil)
+      
+    } else if call.method == "clearAppNotificationsByTag" {
+      if #available(iOS 10.0, *) {
+        let args = call.arguments as! Dictionary<String, String>
+        let tag = args["tag"]!
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [tag])
+      }
+      result(nil)
+
+    } else if call.method == "clearAppNotificationsByTagThatContains" {
+      if #available(iOS 10.0, *) {
+        let args = call.arguments as! Dictionary<String, String>
+        let pattern = args["pattern"]!
+
+        UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
+          let matchingIdentifiers = notifications
+            .filter { $0.request.identifier.contains(pattern) }
+            .map { $0.request.identifier }
+
+          UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: matchingIdentifiers)
         }
-        result(nil)
-    } else if(call.method == "clearAppNotificationsByTag") {
-        if #available(iOS 10.0, *) {
-            let args = call.arguments as! Dictionary<String, String>
-            let tag = args["tag"]! as String
-            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [tag])
-        }
-        result(nil)
-    } else if(call.method == "resetBadgeCountAndRemoveNotificationsFromCenter") {
-        UIApplication.shared.applicationIconBadgeNumber = 0
-        if #available(iOS 10.0, *) {
-            UNUserNotificationCenter.current().removeAllDeliveredNotifications()
-        }
-        result(nil)
-    } else if(call.method == "resetBadgeCountButKeepNotificationsInCenter") {
-        UIApplication.shared.applicationIconBadgeNumber = -1
-        result(nil)
+      }
+      result(nil)
+
+    } else if call.method == "resetBadgeCountAndRemoveNotificationsFromCenter" {
+      UIApplication.shared.applicationIconBadgeNumber = 0
+      if #available(iOS 10.0, *) {
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+      }
+      result(nil)
+
+    } else if call.method == "resetBadgeCountButKeepNotificationsInCenter" {
+      UIApplication.shared.applicationIconBadgeNumber = -1
+      result(nil)
+
     } else {
-        result(FlutterMethodNotImplemented)
+      result(FlutterMethodNotImplemented)
     }
   }
 }

--- a/ios/Classes/SwiftEraserPlugin.swift
+++ b/ios/Classes/SwiftEraserPlugin.swift
@@ -29,13 +29,13 @@ public class SwiftEraserPlugin: NSObject, FlutterPlugin {
         let args = call.arguments as! Dictionary<String, String>
         let pattern = args["pattern"]!
 
-        // UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
-        //   let matchingIdentifiers = notifications
-        //     .filter { $0.request.identifier.contains(pattern) }
-        //     .map { $0.request.identifier }
+        UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
+          let matchingIdentifiers = notifications
+            .filter { $0.request.identifier.contains(pattern) }
+            .map { $0.request.identifier }
 
-        //   UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: matchingIdentifiers)
-        // }
+          UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: matchingIdentifiers)
+        }
       }
       result(nil)
 

--- a/ios/Classes/SwiftEraserPlugin.swift
+++ b/ios/Classes/SwiftEraserPlugin.swift
@@ -29,13 +29,13 @@ public class SwiftEraserPlugin: NSObject, FlutterPlugin {
         let args = call.arguments as! Dictionary<String, String>
         let pattern = args["pattern"]!
 
-        UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
-          let matchingIdentifiers = notifications
-            .filter { $0.request.identifier.contains(pattern) }
-            .map { $0.request.identifier }
+        // UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
+        //   let matchingIdentifiers = notifications
+        //     .filter { $0.request.identifier.contains(pattern) }
+        //     .map { $0.request.identifier }
 
-          UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: matchingIdentifiers)
-        }
+        //   UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: matchingIdentifiers)
+        // }
       }
       result(nil)
 

--- a/lib/eraser.dart
+++ b/lib/eraser.dart
@@ -37,6 +37,24 @@ class Eraser {
     }
   }
 
+  /// Clears all push notifications that have been received by your Flutter app that container the specified pattern in their [tag].
+  ///
+  /// The tag is specified in the payload of the notification.
+  /// Android notification payloads have a 'tag' property where this should be specified.
+  /// While on iOS, the tag should be placed in the apns-collapse-id header.
+  static Future<void> clearAppNotificationsByTagThatContains(
+      String pattern) async {
+    try {
+      await _channel.invokeMethod(
+          'clearAppNotificationsByTagThatContains', <String, dynamic>{
+        'pattern': pattern,
+      });
+    } on PlatformException catch (e) {
+      print(
+          'Failed to clear app notifications for pattern ($pattern) for following reason: ${e.message}');
+    }
+  }
+
   /// Sets the iOS applicationIconBadgeNumber to 0, thus removing the badge count from the app icon.
   /// Doing this also means that the notifications are removed from the iOS notifications center at the same time.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: eraser
 description: A flutter plugin that allows remote push notifications to be dismissed and the iOS badge count to be reset.
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/Wes1324/eraser
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: ">=2.12.0 <4.0.0"
   flutter: ">=1.20.0"
 
 dependencies:


### PR DESCRIPTION
In apps like "WhatsApp"  when you enter specific chat they clear all the notifications from that specific chat, now you can achieve this using the package by creating tag that contains the group id + uuid and simply clear all the notifications that contains the group id